### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,15 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
+
+before_script: composer instal
 
 script:
-  - composer install && vendor/bin/phpunit --configuration tests/phpunit.xml
+  - vendor/bin/phpunit --configuration tests/phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "jimbojsb/swurl",
     "description": "URL Parser / Manipulator",
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "^4.8|^6.5|^7.0"
     },
     "license": "MIT",
     "authors": [
@@ -14,6 +14,11 @@
     "autoload": {
         "psr-4": {
             "Swurl\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "SwUrl\\Tests\\": "tests/"
         }
     }
 }

--- a/tests/AuthInfoTest.php
+++ b/tests/AuthInfoTest.php
@@ -1,7 +1,10 @@
 <?php
-use Swurl\AuthInfo;
+namespace SwUrl\Tests;
 
-class AuthInfoTest extends PHPUnit_Framework_TestCase
+use Swurl\AuthInfo;
+use PHPUnit\Framework\TestCase;
+
+class AuthInfoTest extends TestCase
 {
     public function testToString()
     {

--- a/tests/EncodeableTest.php
+++ b/tests/EncodeableTest.php
@@ -1,7 +1,11 @@
 <?php
-class EncodeableTest extends PHPUnit_Framework_TestCase
+namespace SwUrl\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class EncodeableTest extends TestCase
 {
-    use Swurl\Encodeable;
+    use \Swurl\Encodeable;
 
     public function testEncode()
     {

--- a/tests/FragmentTest.php
+++ b/tests/FragmentTest.php
@@ -1,7 +1,10 @@
 <?php
-use Swurl\Fragment;
+namespace SwUrl\Tests;
 
-class FragmentTest extends PHPUnit_Framework_TestCase
+use Swurl\Fragment;
+use PHPUnit\Framework\TestCase;
+
+class FragmentTest extends TestCase
 {
     public function testToString()
     {

--- a/tests/HostTest.php
+++ b/tests/HostTest.php
@@ -1,7 +1,10 @@
 <?php
-use Swurl\Host;
+namespace SwUrl\Tests;
 
-class HostTest extends PHPUnit_Framework_TestCase
+use Swurl\Host;
+use PHPUnit\Framework\TestCase;
+
+class HostTest extends TestCase
 {
     public function testToString()
     {

--- a/tests/PathTest.php
+++ b/tests/PathTest.php
@@ -1,7 +1,10 @@
 <?php
-use Swurl\Path;
+namespace SwUrl\Tests;
 
-class PathTest extends PHPUnit_Framework_TestCase
+use Swurl\Path;
+use PHPUnit\Framework\TestCase;
+
+class PathTest extends TestCase
 {
     public function testToString()
     {

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -1,7 +1,10 @@
 <?php
-use Swurl\Query;
+namespace SwUrl\Tests;
 
-class QueryTest extends PHPUnit_Framework_TestCase
+use Swurl\Query;
+use PHPUnit\Framework\TestCase;
+
+class QueryTest extends TestCase
 {
     public function testConstruct()
     {
@@ -55,6 +58,6 @@ class QueryTest extends PHPUnit_Framework_TestCase
     public function testNoticeOnNonExistentKey()
     {
         $q = new Query();
-        $p = $q["p"];
+        $this->assertNull($q["p"]);
     }
 }

--- a/tests/SchemeTest.php
+++ b/tests/SchemeTest.php
@@ -1,7 +1,10 @@
 <?php
-use Swurl\Scheme;
+namespace SwUrl\Tests;
 
-class SchemeTest extends PHPUnit_Framework_TestCase
+use Swurl\Scheme;
+use PHPUnit\Framework\TestCase;
+
+class SchemeTest extends TestCase
 {
     public function testSecure()
     {

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -1,7 +1,10 @@
 <?php
-use Swurl\Url;
+namespace SwUrl\Tests;
 
-class UrlTest extends PHPUnit_Framework_TestCase
+use Swurl\Url;
+use PHPUnit\Framework\TestCase;
+
+class UrlTest extends TestCase
 {
     public function testToString()
     {

--- a/tests/phpunit
+++ b/tests/phpunit
@@ -1,1 +1,0 @@
-../vendor/bin/phpunit

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0"?>
-<phpunit stopOnFailure="false" stopOnError="false">
+<phpunit bootstrap="../vendor/autoload.php" stopOnFailure="false" stopOnError="false">
     <testsuite>
         <directory suffix="Test.php">.</directory>
     </testsuite>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">../src</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
# Changed log
- Set the multiple PHPUnit version for the different PHP version tests.
- Use the class-based PHPUnit namespace to be compatible with the latest PHPUnit version.
- Set the correct ```phpunit.xml``` setting.
- Set the correct ```.travis.yml```.
- Use the ```SwUrl\Tests``` namespace for the related tests classes.