### PR TITLE
fix: foreach() argument must be of type array|object, null given

### DIFF
--- a/src/Parsable.php
+++ b/src/Parsable.php
@@ -97,7 +97,7 @@ abstract class Parsable implements IteratorAggregate, Countable, ArrayAccess
         $results = array();
         foreach ($pairs as $key => $value) {
             $keyEncoded = empty($keyParent) ? $this->encode($key) : $keyParent.'['.(is_string($key) ? $this->encode($key) : '').']';
-            if (is_scalar($value)) {
+            if (empty($value) || is_scalar($value)) {
                 $results[] = $keyEncoded.($this->useAssignmentIfEmpty() || !empty($value) ? '=' : '').$this->encode($value);
             } else {
                 $results[] = $this->toStringPairs($value, $keyEncoded);

--- a/tests/FragmentTest.php
+++ b/tests/FragmentTest.php
@@ -6,6 +6,15 @@ use PHPUnit\Framework\TestCase;
 
 class FragmentTest extends TestCase
 {
+    public function testConstruct()
+    {
+        $f = new Fragment(["foo" => null]);
+        $this->assertEquals("#foo", (string) $f);
+
+        $f = new Fragment(["foo" => "bar"]);
+        $this->assertEquals("#foo=bar", (string) $f);
+    }
+
     public function testToString()
     {
         $f = new Fragment("foo");

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -9,6 +9,9 @@ class QueryTest extends TestCase
 {
     public function testConstruct()
     {
+        $q = new Query(["foo" => null]);
+        $this->assertEquals("?foo=", $q->__toString());
+
         $q = new Query(["foo" => "bar"]);
         $this->assertEquals("?foo=bar", $q->__toString());
 


### PR DESCRIPTION
if a Parsable object is instantiated with an associative array with null values then an error is generated `foreach() argument must be of type array|object, null given` when cast to a string.
- new Query and Fragment unit tests created
- fix for error in Parsable